### PR TITLE
Prevent NRE when ArtworkUrl is not set.

### DIFF
--- a/SoundCloudDownloader.Core/Tagging/MediaTagInjector.cs
+++ b/SoundCloudDownloader.Core/Tagging/MediaTagInjector.cs
@@ -68,7 +68,12 @@ public class MediaTagInjector
         TrackInformation track,
         CancellationToken cancellationToken = default)
     {
-        var url = track.ArtworkUrl!.ToString().Replace("large", "t500x500").Replace("small", "t500x500");
+        var url = track.ArtworkUrl?.ToString().Replace("large", "t500x500").Replace("small", "t500x500");
+
+        if (url == null)
+        {
+            await Task.CompletedTask;
+        }
 
         mediaFile.SetThumbnail(
             await Http.Client.GetByteArrayAsync(url, cancellationToken)

--- a/SoundCloudDownloader/Converters/TrackToHighestQualityArtworkUrlConverter.cs
+++ b/SoundCloudDownloader/Converters/TrackToHighestQualityArtworkUrlConverter.cs
@@ -12,7 +12,7 @@ public class TrackToHighestQualityArtworkUrlConverter : IValueConverter
 
     public object? Convert(object? value, Type targetType, object parameter, CultureInfo culture) =>
         value is TrackInformation track
-            ? track.ArtworkUrl!.ToString().Replace("large", "t500x500").Replace("small", "t500x500")
+            ? track.ArtworkUrl?.ToString().Replace("large", "t500x500").Replace("small", "t500x500")
             : null;
 
     public object ConvertBack(object? value, Type targetType, object parameter, CultureInfo culture) =>


### PR DESCRIPTION
Prevent showing a message box with an NRE when `ArtworkUrl` is not set.

Use the following URLs to test:
(1) https://soundcloud.com/tomcr00se/5am-in-silicon-valley
(2) https://soundcloud.com/user-223423313/flight-systems-01-approach-to-tucson

Before:
![image](https://user-images.githubusercontent.com/12585988/191336044-15ec057d-fdce-4886-9703-2f04a6d8ddd1.png)

After:
![image](https://user-images.githubusercontent.com/12585988/191336077-89bcda85-9ecc-4f98-b91d-1cd48533dec6.png)


