### PR TITLE
Display track duration in a human readable format.

### DIFF
--- a/SoundCloudDownloader/Converters/TrackDurationToHumanReadableFormatConverter.cs
+++ b/SoundCloudDownloader/Converters/TrackDurationToHumanReadableFormatConverter.cs
@@ -1,0 +1,33 @@
+﻿using System;
+using System.Globalization;
+using System.Windows.Data;
+
+namespace SoundCloudDownloader.Converters;
+
+[ValueConversion(typeof(long?), typeof(string))]
+public class TrackDurationToHumanReadableFormatConverter : IValueConverter
+{
+    public static TrackDurationToHumanReadableFormatConverter Instance { get; } = new();
+
+    public object Convert(object? value, Type targetType, object parameter, CultureInfo culture)
+    {
+        if (value is long trackDuration)
+        {
+            var duration = TimeSpan.FromMilliseconds(trackDuration);
+
+            if (duration.TotalSeconds < 3600)
+            {
+                return string.Format("{0}:{1:0#}.{2:000}", duration.Minutes, duration.Seconds, duration.Milliseconds);
+            }
+            else
+            {
+                return string.Format("{0}:{1:0#}:{2:0#}.{3:000}", (int)duration.TotalHours, duration.Minutes, duration.Seconds, duration.Milliseconds);
+            }
+        }
+
+        return null!;
+    }
+
+    public object ConvertBack(object? value, Type targetType, object parameter, CultureInfo culture) =>
+        throw new NotSupportedException();
+}

--- a/SoundCloudDownloader/Views/Dialogs/DownloadMultipleSetupView.xaml
+++ b/SoundCloudDownloader/Views/Dialogs/DownloadMultipleSetupView.xaml
@@ -114,8 +114,8 @@
                                             Margin="3,0,0,0"
                                             VerticalAlignment="Center"
                                             FontWeight="Light"
-                                            Text="{Binding Duration, TargetNullValue=Live}"
-                                            TextTrimming="CharacterEllipsis" />
+                                            Text="{Binding Duration, TargetNullValue=Live, Converter={x:Static converters:TrackDurationToHumanReadableFormatConverter.Instance}, Mode=OneWay}"
+                                            TextTrimming="None" />
                                     </StackPanel>
                                 </StackPanel>
                             </StackPanel>

--- a/SoundCloudDownloader/Views/Dialogs/DownloadSingleSetupView.xaml
+++ b/SoundCloudDownloader/Views/Dialogs/DownloadSingleSetupView.xaml
@@ -48,6 +48,7 @@
                         Margin="3,0,0,0"
                         VerticalAlignment="Center"
                         FontWeight="Light"
+                        Width="340"
                         Text="{Binding Track.Title}"
                         TextTrimming="CharacterEllipsis" />
                 </StackPanel>
@@ -64,8 +65,8 @@
                         Margin="3,0,0,0"
                         VerticalAlignment="Center"
                         FontWeight="Light"
-                        Text="{Binding Track.Duration, TargetNullValue=Live}"
-                        TextTrimming="CharacterEllipsis" />
+                        Text="{Binding Track.Duration, TargetNullValue=Live, Converter={x:Static converters:TrackDurationToHumanReadableFormatConverter.Instance}, Mode=OneWay}"
+                        TextTrimming="None" />
                 </StackPanel>
             </StackPanel>
         </StackPanel>


### PR DESCRIPTION
**NOTE: This is a work in progress so please do not merge yet!**

I've added a converter to display the raw track duration value (which is in milliseconds) in a human-readable format (hours, minutes, seconds, and milliseconds) very similar to the format SoundCloud uses (the one that is overlayed in the right part of the waveform). The only difference is that I also included the milliseconds, but we can remove them if it's too much information so that we don't clutter the interface.

Another issue that I've noticed is that when the `Title` is too large it expands and the duration is not visible anymore so I've added a `Width` as a temporary workaround. This is not ideal as the controls are not aligned properly (i.e., the `Duration` is not aligned to the right and the `Title` does not fill the remaining horizontal space. I have little to no experience with WPF so I don't know how to properly fix this.

I've posted some screenshots below.

Test URLs:

(1) https://soundcloud.com/user-223423313/flight-systems-01-approach-to-tucson
(2) https://soundcloud.com/user-223423313/faa-audio-jetpack-guythewarzonecom
(3) https://soundcloud.com/markusschulz/montrealsolo2017part1
(4) https://soundcloud.com/djoptick/optick-live-rituals-egypt-03092022-opening-set-for-francis-mercier-themba


Before:

_Duration shows the raw value in milliseconds._
![image](https://user-images.githubusercontent.com/12585988/191362127-6ec88ab9-4804-4600-b2ea-019bf50abc0b.png)

_Duration shows the raw value in milliseconds._
![image](https://user-images.githubusercontent.com/12585988/191362147-6471b0fb-2177-4384-9e44-f749f9dc4ad1.png)

_The title is too large and the Duration is not visible._
![image](https://user-images.githubusercontent.com/12585988/191362171-719f800b-397a-417d-bed1-78b5793ed171.png)

After:

_Duration is shown in minutes, seconds, and milliseconds._
![image](https://user-images.githubusercontent.com/12585988/191363327-8ed40031-93fd-4b79-b117-4673ef88779e.png)

_Duration is shown in minutes, seconds, and milliseconds._
![image](https://user-images.githubusercontent.com/12585988/191363724-b81d5bd8-171c-4e51-a7c5-7070259401ec.png)

_Duration is shown in hours, minutes, seconds, and milliseconds._
![image](https://user-images.githubusercontent.com/12585988/191363813-8834dcba-7a8f-46d7-970a-41e7c7906bad.png)

_Duration is shown in hours, minutes, seconds, and milliseconds, but is not aligned to the right._
![image](https://user-images.githubusercontent.com/12585988/191365223-8390aca3-3f1f-42b1-83cc-0355c6f68a27.png)

Let me know what you think. Thank you.


