### PR TITLE
Removed duplicated code that injects media tags.

### DIFF
--- a/SoundCloudDownloader.Core/Downloading/TrackDownloader.cs
+++ b/SoundCloudDownloader.Core/Downloading/TrackDownloader.cs
@@ -3,7 +3,6 @@ using System.IO;
 using System.Threading;
 using System.Threading.Tasks;
 using Gress;
-using SoundCloudDownloader.Core.Tagging;
 using SoundCloudExplode;
 using SoundCloudExplode.Track;
 
@@ -12,7 +11,6 @@ namespace SoundCloudDownloader.Core.Downloading;
 public class TrackDownloader
 {
     private readonly SoundCloudClient _soundcloud = new();
-    private readonly MediaTagInjector _tagInjector = new();
 
     public async Task DownloadAsync(
         string filePath,
@@ -30,14 +28,5 @@ public class TrackDownloader
             progress?.ToDoubleBased(),
             cancellationToken
         );
-
-        try
-        {
-            await _tagInjector.InjectTagsAsync(filePath, track, cancellationToken);
-        }
-        catch
-        {
-            // Not critical, ignore
-        }
     }
 }


### PR DESCRIPTION
NOTE: The media tags are already injected within the `EnqueueDownload` method in `DashboardViewModel` which also obeys the user settings.